### PR TITLE
下载 pcm 文件时自动命名为 .pcm 格式

### DIFF
--- a/audio/js/main.js
+++ b/audio/js/main.js
@@ -44,4 +44,5 @@ downPcm.addEventListener("click", () => {
   if(recorder === null) return alert("请先录音")
   const src = recorder.pcmSrc()
   downPcm.setAttribute("href", src)
+  downPcm.setAttribute('download', src.split('/')[3] + '.pcm'); // 命名为 pcm 格式
 })


### PR DESCRIPTION
下载 pcm 文件时自动命名为 .pcm 格式，无需再手动修改 .txt 文件名